### PR TITLE
Fixing error on line 21

### DIFF
--- a/Quellcode/chap_3/iris_classification.py
+++ b/Quellcode/chap_3/iris_classification.py
@@ -18,7 +18,7 @@ data_train.loc[data_train['species']=='Iris-virginica', 'species']=2
 data_train = data_train.apply(pd.to_numeric)
 
 # Der eingelesene Datenset wird als Matrix dargestellt
-data_train_array = data_train.as_matrix()
+data_train_array = data_train.to_numpy()
 
 # Das Datenset wird in zwei separate Kategorie gespaltet: Testdaten und Trainingsdaten. 
 # 80% der Daten werden zum Trainieren und 20% zum Testen des Modells verwendet. 


### PR DESCRIPTION
Original line "data_train_array = data_train.as_matrix()" gives following error:

Traceback (most recent call last):
  File "iris_classification.py", line 21, in <module>
    data_train_array = data_train.as_matrix()
  File "C:\Users\leonc\anaconda3\envs\dl_env\lib\site-packages\pandas\core\generic.py", line 5274, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'as_matrix'

pandas suggests using .to_numpy() https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_numpy.html#pandas.DataFrame.to_numpy

Note: should be changed in iris_classification_variante_1.py and iris_classification_variante_2.py as well